### PR TITLE
support windows

### DIFF
--- a/container/provider.go
+++ b/container/provider.go
@@ -27,11 +27,12 @@ import (
 	"github.com/it-chain/tesseract/docker"
 	"github.com/it-chain/tesseract/logger"
 	"github.com/it-chain/tesseract/rpc"
+	"fmt"
 )
 
 var ErrFailedPullImage = errors.New("failed to pull image")
 var defaultPort = "50001"
-var ipAddress = "127.0.0.1"
+var ipAddress = "192.168.99.100"
 
 func Create(config tesseract.ContainerConfig) (DockerContainer, error) {
 
@@ -57,6 +58,8 @@ func Create(config tesseract.ContainerConfig) (DockerContainer, error) {
 		port,
 	)
 
+	fmt.Println("Res", res)
+
 	if err != nil {
 		return DockerContainer{}, err
 	}
@@ -72,7 +75,7 @@ func Create(config tesseract.ContainerConfig) (DockerContainer, error) {
 	client, err := createClient()
 
 	if err != nil {
-		logger.Errorf(nil, "[Tesseract] closing container %d", res.ID)
+		logger.Errorf(nil, "[Tesseract] closing container %s", res.ID)
 		docker.KillContainer(res.ID)
 		docker.RemoveContainer(res.ID)
 		return DockerContainer{}, err
@@ -147,7 +150,7 @@ func retryConnectWithTimeOut(timeout time.Duration) (*rpc.ClientStream, error) {
 
 		for _ = range ticker.C {
 			client, err := rpc.NewClientStream(ipAddress + ":" + defaultPort)
-
+			fmt.Println("err1", err)
 			if err != nil {
 				continue
 			}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -213,6 +213,14 @@ func GetPorts() ([]types.Port, error) {
 	return portList, nil
 }
 
+func GetHostIpAddress() string {
+	cli, _ := docker.NewEnvClient()
+	defer cli.Close()
+
+	host, _ := docker.ParseHostURL(cli.DaemonHost())
+	return strings.Split(host.Host, ":")[0]
+}
+
 func makeICodeLogDir(srcPath string) error {
 	logDirPath := makeICodeLogPath(srcPath)
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -55,7 +55,7 @@ func CreateContainer(containerImage tesseract.ContainerImage, srcPath string, de
 
 	containerName := makeICodeContainerName(srcPath)
 	if IsContainerExist(containerName) {
-		logger.Info(nil, fmt.Sprintf("[tesseract] container name \"/%s\" exist, container name now random generated", containerName))
+		logger.Info(nil, fmt.Sprintf("[tesseract] container name \"%s\" exist, container name now random generated", containerName))
 		containerName = ""
 	}
 
@@ -261,14 +261,13 @@ func makeICodeLogDir(srcPath string) error {
 
 func makeICodeLogPath(srcPath string) string {
 	icodePath := srcPath
+	logDir := fmt.Sprintf("icode_%s", filepath.Base(srcPath))
 
 	if runtime.GOOS == "windows" {
 		icodePath = ConvertToAbsPathForWindows(icodePath)
-		logDir := fmt.Sprintf("icode_%s", filepath.Base(srcPath))
-		return path.Join(ConvertToAbsPathForWindows(srcPath), "../logs", logDir)
 	}
 
-	return path.Join(srcPath, "../logs", fmt.Sprintf("icode_%s", filepath.Base(srcPath)))
+	return path.Join(icodePath, "../logs", logDir)
 }
 
 func makeICodePath(srcPath string) string {

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -42,6 +42,43 @@ func TestCreateContainerWithCellCode(t *testing.T) {
 	assert.Equal(t, "/container_mock", containerName)
 }
 
+func TestCreateContainer_WhenSameNamedContainerExist_RandomGenerateName(t *testing.T) {
+	defer setup(t, removeAllContainers)()
+
+	GOPATH := os.Getenv("GOPATH")
+	// when
+	res, err := docker.CreateContainer(
+		tesseract.GetDefaultImage(),
+		GOPATH + "/src/github.com/it-chain/tesseract/mock",
+		"github.com/mock",
+		"50005",
+	)
+	// then
+	assert.NoError(t, err)
+
+	// when
+	containerName, err := getContainerName(res.ID)
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, "/container_mock", containerName)
+
+	// when
+	res2, err := docker.CreateContainer(
+		tesseract.GetDefaultImage(),
+		GOPATH + "/src/github.com/it-chain/tesseract/mock",
+		"github.com/mock",
+		"50005",
+	)
+	// then
+	assert.NoError(t, err)
+
+	// when
+	randomGeneratedName, err := getContainerName(res2.ID)
+	// then
+	assert.NoError(t, err)
+	assert.NotEqual(t, "/container_mock", randomGeneratedName)
+}
+
 func TestStartContainer(t *testing.T) {
 	defer setup(t, removeAllContainers)()
 

--- a/rpc/client_stream.go
+++ b/rpc/client_stream.go
@@ -28,14 +28,12 @@ func NewClientStream(address string) (*ClientStream, error) {
 	dialContext, _ := context.WithTimeout(context.Background(), defaultDialTimeout)
 
 	conn, err := grpc.DialContext(dialContext, address, grpc.WithInsecure())
-
 	if err != nil {
 		return nil, err
 	}
 	ctx, cf := context.WithCancel(context.Background())
 	client := pb.NewBistreamServiceClient(conn)
 	clientStream, err := client.RunICode(ctx)
-
 	if err != nil {
 		//conn.Close()
 		//cf()


### PR DESCRIPTION
related issue: #38 , #39 

Details: 
1. Support windows
2. Instead of throw error when same container name exist, random generate container name

- [x] test code